### PR TITLE
commit Added possibility to use addresses with spaces. 

### DIFF
--- a/modules/bot_assistant/handlers/contact_handlers.py
+++ b/modules/bot_assistant/handlers/contact_handlers.py
@@ -107,10 +107,17 @@ def remove_phone(args, address_book):
 
 @input_error
 def add_address(args, address_book):
-    if len(args) != 2:
+    if len(args) < 2:
         raise exceptions.InvalidArgsError
-    name, address = args
-
+    name = args.pop(0)
+    address_str = ''
+    for arg in args:
+        if address_str == '':
+            address_str = address_str + arg
+        else:
+            address_str = address_str + " " + arg
+    
+    address = address_str
     if name not in address_book.data:
         raise exceptions.ContactDoesNotExistError
 
@@ -124,10 +131,22 @@ def add_address(args, address_book):
 
 @input_error
 def edit_address(args, address_book):
-    if len(args) != 3:
+    if len(args) < 3:
         raise exceptions.InvalidArgsError
-    name, address, new_address = args
-
+    #name, address, new_address = args
+    name = args.pop(0)
+    address_str = ''
+    for arg in args:
+        if address_str == '':
+            address_str = address_str + arg
+        else:
+            address_str = address_str + " " + arg
+    addresses_list = address_str.split("; ")
+    if len(addresses_list) != 2:
+        raise exceptions.InvalidArgsError
+    else:
+        address = addresses_list[0]
+        new_address = addresses_list[1]
     if name not in address_book.data:
         raise exceptions.ContactDoesNotExistError
 
@@ -155,10 +174,16 @@ def get_contact_address(args, address_book):
 
 @input_error
 def remove_address(args, address_book):
-    if len(args) != 2:
+    if len(args) < 2:
         raise exceptions.InvalidArgsError
-    name, address = args
-
+    name = args.pop(0)
+    address_str = ''
+    for arg in args:
+        if address_str == '':
+            address_str = address_str + arg
+        else:
+            address_str = address_str + " " + arg
+    address = address_str
     if name not in address_book.data:
         raise exceptions.ContactDoesNotExistError
 


### PR DESCRIPTION
Added possibility to use addresses with spaces. In case of address edit (command "edit-address") user should use semicolon with space (; ) between old and new addresses.
![Addresses5](https://github.com/CarpathianUA/bot-assistant/assets/143954608/193591d1-1157-4ba2-bdea-16891ec06079)
Changes made in two files: 
1) \bot-assistant\modules\bot_assistant\handlers\contact_handlers.py
2) \bot-assistant\modules\bot_assistant\constants\commands.py